### PR TITLE
feat: reward amount from f64 to string

### DIFF
--- a/commenceSaga.go
+++ b/commenceSaga.go
@@ -46,8 +46,7 @@ func (RankingsUsersRewardPayload) Type() SagaTitle {
 
 type CryptoRankingWinners struct {
 	UserID string `json:"userId"`
-	// float64 because of the number of decimals it can have
-	Reward float64 `json:"reward"`
+	Reward string `json:"reward"`
 }
 
 type CompletedCryptoRanking struct {


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

This pull request includes a change to the `saga/commenceSaga.go` file. The change modifies the `CryptoRankingWinners` struct to change the type of the `reward` field from `float64` to `string`.

### `docs`
Changed the type of the `reward` field in the `CryptoRankingWinners` struct from `float64` to `string` to ensure proper handling of reward values.
