### PR TITLE
feat(events): add intermediate rewards support

### DIFF
--- a/event/microserviceEvent.go
+++ b/event/microserviceEvent.go
@@ -28,6 +28,7 @@ const (
 	LegendMissionsSendEmailNftMissionCompletedEvent          MicroserviceEvent = "legend_missions.send_email_nft_mission_completed"
 	LegendRankingsRankingsFinishedEvent                      MicroserviceEvent = "legend_rankings.rankings_finished"
 	LegendRankingsNewRankingCreatedEvent                     MicroserviceEvent = "legend_rankings.new_ranking_created"
+	LegendRankingsIntermediateRewardEvent                    MicroserviceEvent = "legend_rankings.intermediate_reward"
 	LegendShowcaseProductVirtualDeletedEvent                 MicroserviceEvent = "legend_showcase.product_virtual_deleted"
 	LegendShowcaseUpdateAllowedMissionSubscriptionIdsEvent   MicroserviceEvent = "legend_showcase.update_allowed_mission_subscription_ids"
 	LegendShowcaseUpdateAllowedRankingSubscriptionIdsEvent   MicroserviceEvent = "legend_showcase.update_allowed_ranking_subscription_ids"
@@ -64,6 +65,7 @@ func MicroserviceEventValues() []MicroserviceEvent {
 		LegendMissionsSendEmailNftMissionCompletedEvent,
 		LegendRankingsRankingsFinishedEvent,
 		LegendRankingsNewRankingCreatedEvent,
+		LegendRankingsIntermediateRewardEvent,
 		LegendShowcaseProductVirtualDeletedEvent,
 		LegendShowcaseUpdateAllowedMissionSubscriptionIdsEvent,
 		LegendShowcaseUpdateAllowedRankingSubscriptionIdsEvent,
@@ -314,6 +316,20 @@ type NotificationConfig struct {
 
 func (LegendRankingsNewRankingCreatedEventPayload) Type() MicroserviceEvent {
 	return LegendRankingsNewRankingCreatedEvent
+}
+
+// LegendRankingsIntermediateRewardEventPayload is the payload for the legend_rankings.intermediate_reward event.
+type LegendRankingsIntermediateRewardEventPayload struct {
+	UserID                 string                 `json:"userId"`
+	RankingID              int                    `json:"rankingId"`
+	IntermediateRewardType string                 `json:"intermediateRewardType"`
+	RewardConfig           map[string]interface{} `json:"rewardConfig"`
+	TemplateName           string                 `json:"templateName"`
+	TemplateData           map[string]interface{} `json:"templateData"`
+}
+
+func (LegendRankingsIntermediateRewardEventPayload) Type() MicroserviceEvent {
+	return LegendRankingsIntermediateRewardEvent
 }
 
 // LegendShowcaseProductVirtualDeletedEventPayload is the payload for the legend_showcase.product_virtual_deleted event.


### PR DESCRIPTION
## Ticket:
https://legendaryum.atlassian.net/browse/LE-3640

## Resumen
Se agregó soporte para evento legend_rankings.intermediate_reward que entrega recompensas automáticas durante participación activa en rankings, de momento se entregara solo al hito de la primera partida (first_game,) que es lo que se pidio (puede llegar a escalar en un futuro con otros hitos y tipos de reward.

## Uso
Se emite cuando usuario alcanza milestones específicos (first_game) desde Rankings hacia microservicio de email.
